### PR TITLE
Fix library dependencies for old PowerPC linux builds

### DIFF
--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -1,5 +1,5 @@
 name:         bindings-GLFW
-version:      3.0.3.2
+version:      3.0.3.3
 category:     Graphics
 
 author:       Brian Lewis <brian@lorf.org>


### PR DESCRIPTION
This is a somewhat small bugfix. Really old PowerPC based linux builds do not support all of the floating point operations that modern processors do. Hence they use software implementations of some floating point operations. After installing GLFW and running the tests successfully, I was unable to build some of the haskell GLFW examples. Adding a linking option to gcc_s for PPC architectures seems to solve this.
