### PR TITLE
workaround to build on GHC 7.8.3 Win64

### DIFF
--- a/glfw/src/cocoa_clipboard.m
+++ b/glfw/src/cocoa_clipboard.m
@@ -29,6 +29,9 @@
 #include <limits.h>
 #include <string.h>
 
+#if _WIN64
+#define strdup _strdup
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW platform API                      //////

--- a/glfw/src/cocoa_monitor.m
+++ b/glfw/src/cocoa_monitor.m
@@ -31,6 +31,9 @@
 #include <limits.h>
 
 #include <IOKit/graphics/IOGraphicsLib.h>
+#if _WIN64
+#define strdup _strdup
+#endif
 
 
 // Get the name of the specified display

--- a/glfw/src/monitor.c
+++ b/glfw/src/monitor.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <limits.h>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || _WIN64
  #include <malloc.h>
  #define strdup _strdup
 #endif

--- a/glfw/src/x11_clipboard.c
+++ b/glfw/src/x11_clipboard.c
@@ -31,6 +31,9 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if _WIN64
+#define strdup _strdup
+#endif
 
 // Returns whether the event is a selection event
 //


### PR DESCRIPTION
The use of `strdup` causes build failure on latest GHC(https://ghc.haskell.org/trac/ghc/ticket/9215). Here is a workaround to fix it.
