### PR TITLE
Fix version numbers in the Test

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -54,8 +54,8 @@ main = do
 
 versionMajor, versionMinor, versionRevision :: Int
 versionMajor    = 3
-versionMinor    = 0
-versionRevision = 3
+versionMinor    = 1
+versionRevision = 0
 
 giveItTime :: IO ()
 giveItTime = threadDelay 500000


### PR DESCRIPTION
Also, I think that tests that only work under a graphic environment should not be enabled by default. Maybe protect it with a cabal flag?

And, tests that assume some specific window manager behavior should be marked as so. (Eg. under i3 the 'window pos', the 'cursor pos' and the 'iconification' tests fail.)