### PR TITLE
Workaround for Windows (x64), again

### DIFF
--- a/glfw/src/monitor.c
+++ b/glfw/src/monitor.c
@@ -32,6 +32,10 @@
 #include <stdlib.h>
 #include <limits.h>
 
+#if defined(_MSC_VER) || _WIN64
+#include <malloc.h>
+#define strdup _strdup
+#endif
 
 // Lexical comparison function for GLFW video modes, used by qsort
 //


### PR DESCRIPTION
The content of my previous patch (https://github.com/bsl/bindings-GLFW/pull/12) seems to have disappeared just when bindings-GLFW has updated to 3.1. In fact this is causing a build issue on Windows (#27).

This patch re-adds the workaround.