### PR TITLE
Export glfwPostEmptyEvents

### DIFF
--- a/Bindings/GLFW.hsc
+++ b/Bindings/GLFW.hsc
@@ -345,6 +345,7 @@ deriving instance Data     C'GLFWwindow
 #ccall glfwSetFramebufferSizeCallback , Ptr <GLFWwindow> -> <GLFWframebuffersizefun> ->                       IO <GLFWframebuffersizefun>
 #ccall glfwPollEvents                 ,                                                                       IO ()
 #ccall glfwWaitEvents                 ,                                                                       IO ()
+#ccall glfwPostEmptyEvent             ,                                                                       IO ()
 #ccall glfwGetInputMode               , Ptr <GLFWwindow> -> CInt ->                                           IO CInt
 #ccall glfwSetInputMode               , Ptr <GLFWwindow> -> CInt -> CInt ->                                   IO ()
 #ccall glfwGetKey                     , Ptr <GLFWwindow> -> CInt ->                                           IO CInt


### PR DESCRIPTION
Export `glfwPostEmptyEvents` so it is possible to wake up a thread stuck waiting on `glfwWaitEvents`.