### PR TITLE
Bump template-haskell upper version bounds

### DIFF
--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -104,7 +104,7 @@ library
   build-depends:
     base          < 5,
     bindings-DSL == 1.0.*,
-    template-haskell >= 2.10 && < 2.11
+    template-haskell >= 2.10 && < 2.12
 
   include-dirs:
     glfw/include/GLFW


### PR DESCRIPTION
For GHC 8.0 compatibility.