### PR TITLE
Add system-glfw Cabal flag

### DIFF
--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -49,6 +49,10 @@ extra-source-files:
 
 --------------------------------------------------------------------------------
 
+flag system-GLFW
+  description: Use the system-wide GLFW instead of the bundled copy.
+  default: False
+
 flag MacOSXUseChdir
   description:
     Mac OS X only. Determines whether 'init' changes the current directory of
@@ -108,90 +112,94 @@ library
     bindings-DSL == 1.0.*,
     template-haskell >= 2.10 && < 2.12
 
-  include-dirs:
-    glfw/include/GLFW
-    glfw/include/
-    glfw/src
-
-  c-sources:
-    glfw/src/context.c
-    glfw/src/init.c
-    glfw/src/input.c
-    glfw/src/monitor.c
-    glfw/src/window.c
-
-  cc-options: -D_GLFW_USE_CONFIG_H
-
-  if os(linux) || os(freebsd)
+  if flag(system-glfw)
+    pkgconfig-depends:
+      glfw3 == 3.1.*
+  else
     include-dirs:
-      glfw/include/os/unix-like
-    c-sources:
-      glfw/src/xkb_unicode.c
-      glfw/src/linux_joystick.c
-      glfw/src/posix_time.c
-      glfw/src/posix_tls.c
-    if flag(X)
-      c-sources:
-        glfw/src/glx_context.c
-        glfw/src/x11_init.c
-        glfw/src/x11_monitor.c
-        glfw/src/x11_window.c
-    if flag(Wayland)
-      c-sources:
-        glfw/src/egl_context.c
-        glfw/src/wl_init.c
-        glfw/src/wl_monitor.c
-        glfw/src/wl_window.c
-    if flag(Mir)
-      c-sources:
-        glfw/src/egl_context.c
-        glfw/src/mir_init.c
-        glfw/src/mir_monitor.c
-        glfw/src/mir_window.c
+      glfw/include/GLFW
+      glfw/include/
+      glfw/src
 
-    extra-libraries:
-      GL
-      X11
-      Xi
-      Xrandr
-      Xxf86vm
-      Xcursor
-      Xinerama
-      pthread
-
-  if os(darwin)
-    include-dirs:
-       glfw/include/os/darwin
     c-sources:
-       glfw/src/mach_time.c
-       glfw/src/posix_tls.c
-       glfw/src/cocoa_init.m
-       glfw/src/iokit_joystick.m
-       glfw/src/cocoa_monitor.m
-       glfw/src/cocoa_window.m
-       glfw/src/nsgl_context.m
-    if !flag(MacOSXUseChdir)
-      cc-options: -UGLFW_USE_CHDIR
-    if !flag(MacOSXUseMenubar)
-      cc-options: -UGLFW_USE_MENUBAR
-    if !flag(MacOSXUseRetina)
-      cc-options: -UGLFW_USE_RETINA
-    frameworks: AGL Cocoa OpenGL IOKit CoreFoundation CoreVideo
+      glfw/src/context.c
+      glfw/src/init.c
+      glfw/src/input.c
+      glfw/src/monitor.c
+      glfw/src/window.c
 
-  if os(mingw32)
-    include-dirs:
-      glfw/include/os/windows
-    c-sources:
-      glfw/src/win32_init.c
-      glfw/src/winmm_joystick.c
-      glfw/src/win32_monitor.c
-      glfw/src/win32_time.c
-      glfw/src/win32_window.c
-      glfw/src/win32_tls.c
-      glfw/src/wgl_context.c
-    extra-libraries:
-      opengl32
-      Gdi32
+    cc-options: -D_GLFW_USE_CONFIG_H
+
+    if os(linux) || os(freebsd)
+      include-dirs:
+        glfw/include/os/unix-like
+      c-sources:
+        glfw/src/xkb_unicode.c
+        glfw/src/linux_joystick.c
+        glfw/src/posix_time.c
+        glfw/src/posix_tls.c
+      if flag(X)
+        c-sources:
+          glfw/src/glx_context.c
+          glfw/src/x11_init.c
+          glfw/src/x11_monitor.c
+          glfw/src/x11_window.c
+      if flag(Wayland)
+        c-sources:
+          glfw/src/egl_context.c
+          glfw/src/wl_init.c
+          glfw/src/wl_monitor.c
+          glfw/src/wl_window.c
+      if flag(Mir)
+        c-sources:
+          glfw/src/egl_context.c
+          glfw/src/mir_init.c
+          glfw/src/mir_monitor.c
+          glfw/src/mir_window.c
+
+      extra-libraries:
+        GL
+        X11
+        Xi
+        Xrandr
+        Xxf86vm
+        Xcursor
+        Xinerama
+        pthread
+
+    if os(darwin)
+      include-dirs:
+         glfw/include/os/darwin
+      c-sources:
+         glfw/src/mach_time.c
+         glfw/src/posix_tls.c
+         glfw/src/cocoa_init.m
+         glfw/src/iokit_joystick.m
+         glfw/src/cocoa_monitor.m
+         glfw/src/cocoa_window.m
+         glfw/src/nsgl_context.m
+      if !flag(MacOSXUseChdir)
+        cc-options: -UGLFW_USE_CHDIR
+      if !flag(MacOSXUseMenubar)
+        cc-options: -UGLFW_USE_MENUBAR
+      if !flag(MacOSXUseRetina)
+        cc-options: -UGLFW_USE_RETINA
+      frameworks: AGL Cocoa OpenGL IOKit CoreFoundation CoreVideo
+
+    if os(mingw32)
+      include-dirs:
+        glfw/include/os/windows
+      c-sources:
+        glfw/src/win32_init.c
+        glfw/src/winmm_joystick.c
+        glfw/src/win32_monitor.c
+        glfw/src/win32_time.c
+        glfw/src/win32_window.c
+        glfw/src/win32_tls.c
+        glfw/src/wgl_context.c
+      extra-libraries:
+        opengl32
+        Gdi32
 
   if flag(ExposeNative)
     cc-options: -DExposeNative


### PR DESCRIPTION
[Inspired by the `yaml` library](https://github.com/snoyberg/yaml/blob/64bf8227f517d6bcd9ec37ac3e2bbb342e05e305/yaml.cabal#L37), it would be convenient to have a Cabal flag that allows users to build `bindings-GLFW` using the system installation of GLFW. Among other uses, this flag would, for example, allow Windows users a quick way to hack around [GHC Trac #12031](https://ghc.haskell.org/trac/ghc/ticket/12031) with GHC 8.0.1 (until GHC 8.0.2 is released).
