### PR TITLE
Fix Windows build following db8970a

### DIFF
--- a/glfw/src/monitor.c
+++ b/glfw/src/monitor.c
@@ -32,6 +32,10 @@
 #include <stdlib.h>
 #include <limits.h>
 
+#if defined(_MSC_VER) || _WIN64
+#include <malloc.h>
+#define strdup _strdup
+#endif
 
 // Lexical comparison function for GLFW video modes, used by qsort
 //


### PR DESCRIPTION
The Windows build of `bindings-GLFW` was broken due to commit db8970a713a032c1e0383a0214f7f47272718bb3. @JavierJF [mentioned some ideas](https://github.com/bsl/bindings-GLFW/commit/db8970a713a032c1e0383a0214f7f47272718bb3#commitcomment-19282416) he had to prevent this in the future, but until that gets implemented, re-adding the code from #28 fixes the build.