### PR TITLE
Fix GHC-8.2.1 build (when ExposeNative flag isn't used)

### DIFF
--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -109,8 +109,7 @@ library
 
   build-depends:
     base          < 5,
-    bindings-DSL == 1.0.*,
-    template-haskell >= 2.10 && < 2.12
+    bindings-DSL == 1.0.*
 
   if flag(system-glfw)
     pkgconfig-depends:
@@ -202,6 +201,7 @@ library
         Gdi32
 
   if flag(ExposeNative)
+    build-depends: template-haskell >= 2.10 && < 2.12
     cc-options: -DExposeNative
     exposed-modules:
         Bindings.Helpers


### PR DESCRIPTION
this allows using bindings-GLFW with GHC-8.2.1 / stackage nightly-2017-07-31 and up

the `template-haskell` dependency is used only when the `ExposeNative` flag is used. Note that when this flag is used, bindings-GLFW won't build with new GHC because the `template-haskell` version changed (and `DecsQ` type synonym was removed from it)