### PR TITLE
Increased template-haskell upper bounds to 2.13

### DIFF
--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -110,7 +110,7 @@ library
   build-depends:
     base          < 5,
     bindings-DSL == 1.0.*,
-    template-haskell >= 2.10 && < 2.12
+    template-haskell >= 2.10 && < 2.13
 
   if flag(system-glfw)
     pkgconfig-depends:


### PR DESCRIPTION
Successfully compiled with stackage nightly-2017-08-19 (template-haskell 2.12) using ExposeNative flag.