### PR TITLE
Flexible binding glfwCreateWindowSurface

### DIFF
--- a/Bindings/GLFW.hsc
+++ b/Bindings/GLFW.hsc
@@ -39,6 +39,9 @@ import Prelude (Eq, IO, Num, Show)
 import Prelude (($), return)
 
 import Data.Data        (Data)
+import Data.Int         (Int32)
+import Data.Word        (Word64)
+import Data.Void        (Void)
 import Data.Typeable    (Typeable)
 import Foreign.C.Types  (CChar, CUChar, CUShort)
 import Foreign.C.Types  (CDouble(..), CFloat(..), CInt(..), CUInt(..), CULong(..))
@@ -460,3 +463,4 @@ deriving instance Data     C'GLFWcursor
 
 #ccall glfwVulkanSupported , IO CInt
 #ccall glfwGetRequiredInstanceExtensions , Ptr CUInt -> IO (Ptr CString)
+#ccall glfwCreateWindowSurface , Ptr Void ->  Ptr <GLFWwindow> -> Ptr Void -> Ptr Word64 -> IO Int32

--- a/Bindings/GLFW.hsc
+++ b/Bindings/GLFW.hsc
@@ -40,8 +40,7 @@ import Prelude (($), return)
 
 import Data.Data        (Data)
 import Data.Int         (Int32)
-import Data.Word        (Word64)
-import Data.Void        (Void)
+import Data.Word        (Word32)
 import Data.Typeable    (Typeable)
 import Foreign.C.Types  (CChar, CUChar, CUShort)
 import Foreign.C.Types  (CDouble(..), CFloat(..), CInt(..), CUInt(..), CULong(..))
@@ -462,5 +461,7 @@ deriving instance Data     C'GLFWcursor
 #ccall glfwGetTimerFrequency , IO (CULong)
 
 #ccall glfwVulkanSupported , IO CInt
-#ccall glfwGetRequiredInstanceExtensions , Ptr CUInt -> IO (Ptr CString)
-#ccall glfwCreateWindowSurface , Ptr Void ->  Ptr <GLFWwindow> -> Ptr Void -> Ptr Word64 -> IO Int32
+#ccall glfwGetRequiredInstanceExtensions , Ptr Word32 -> IO (Ptr CString)
+#ccall glfwGetInstanceProcAddress , Ptr vkInstance -> CString -> IO (FunPtr vkProc)
+#ccall glfwGetPhysicalDevicePresentationSupport , Ptr vkInstance -> Ptr vkPhysicalDevice -> Word32 -> IO CInt
+#ccall glfwCreateWindowSurface , Ptr vkInstance ->  Ptr <GLFWwindow> -> Ptr vkAllocationCallbacks -> Ptr vkSurfaceKHR -> IO Int32


### PR DESCRIPTION
Hey, I've got a simple proposal how to add `glfwCreateWindowSurface` without adding new dependencies on other haskell libraries :)

Here is why I think it is a reasonable solution:
  * All parameters are sent in pointers that can be easily cast using `castPtr`
  * Just for clarity, I still use meaningful parameter types:
     * `VkInstance` is a pointer to an opaque data type, thus `Void`
     *  allocator callbacks is a visible type, but still have to put `Void` to avoid dependencies
     * `VkSurfaceKHR` is a non-dispatchable pointer type, which must be 64 bit wide according to spec.
  * Return type is `VkResult`, which is enum and is signed, thus Int32.

[On the `GLFW-b`  side](https://github.com/achirkin/GLFW-b/blob/c57109dfede0a6ca08a7088f371fe29fff315415/Graphics/UI/GLFW.hs#L1269), this looks like this:

```Haskell
-- | Creates a Vulkan surface for the specified window
createWindowSurface :: Enum vkResult
                    => Ptr vkInstance
                       -- ^ VkInstance
                    -> Window
                       -- ^ GLFWwindow *window
                    -> Ptr vkAllocationCallbacks
                       -- ^ const VkAllocationCallbacks *allocator
                    -> Ptr vkSurfaceKHR
                       -- ^ VkSurfaceKHR *surface
                    -> IO vkResult
createWindowSurface i win acs s
  = toEnum . fromIntegral
<$> c'glfwCreateWindowSurface (castPtr i) (toC win) (castPtr acs) (castPtr s)
```

This is not 100% safe, but is better than nothing. [There is no need to do any type casts on the user site.](https://github.com/achirkin/vulkan/blob/b77292cd1828104caf40d58543ab6eb65235a056/vulkan-examples/04-Presentation.hs#L42)


