### PR TITLE
Fix latest stackage build.

### DIFF
--- a/Bindings/GLFW.hsc
+++ b/Bindings/GLFW.hsc
@@ -8,6 +8,7 @@
 #include <bindings.dsl.h>
 #include <GLFW/glfw3.h>
 #ifdef ExposeNative
+  #warning "You are compiling glfw using the native access functions. BEWARE."
 
   #if defined(_WIN32)
 
@@ -43,13 +44,6 @@ import Foreign.C.Types  (CChar, CUChar, CUShort)
 import Foreign.C.Types  (CDouble(..), CFloat(..), CInt(..), CUInt(..))
 import Foreign.Ptr      (FunPtr, Ptr, plusPtr)
 import Foreign.Storable (Storable(..))
-
-#ifdef ExposeNative
-import Bindings.Helpers
-
-$(warn "You are compiling glfw using the native access functions. BEWARE.")
-#endif
-
 --------------------------------------------------------------------------------
 
 #num GL_FALSE

--- a/Bindings/Helpers.hs
+++ b/Bindings/Helpers.hs
@@ -1,6 +1,0 @@
-module Bindings.Helpers where
-
-import Language.Haskell.TH (DecsQ, reportWarning)
-
-warn :: String -> DecsQ
-warn str = reportWarning str >> return []

--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -1,5 +1,5 @@
 name:         bindings-GLFW
-version:      3.1.2.2
+version:      3.1.2.3
 category:     Graphics
 
 author:       Brian Lewis <brian@lorf.org>

--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -109,8 +109,7 @@ library
 
   build-depends:
     base          < 5,
-    bindings-DSL == 1.0.*,
-    template-haskell >= 2.10 && < 2.13
+    bindings-DSL == 1.0.*
 
   if flag(system-glfw)
     pkgconfig-depends:
@@ -203,8 +202,6 @@ library
 
   if flag(ExposeNative)
     cc-options: -DExposeNative
-    exposed-modules:
-        Bindings.Helpers
 
 --------------------------------------------------------------------------------
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2015-08-26
+resolver: nightly-2018-03-22
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Almost all modern versions of GCC support the `#warning` CPP directive. That's a much better way of spewing a warning at compilation time than depending on template-haskell, imo.

The reason stackage was broken was due to version bounds, so I think this takes care of that.