### PR TITLE
Native EGL should always be available on Linux.

### DIFF
--- a/Bindings/GLFW.hsc
+++ b/Bindings/GLFW.hsc
@@ -23,15 +23,15 @@
 
   #elif defined(__linux__)
 
+    #define GLFW_EXPOSE_NATIVE_EGL
+
     #if defined(BINDINGS_GLFW_USE_X11)
       #define GLFW_EXPOSE_NATIVE_X11
       #define GLFW_EXPOSE_NATIVE_GLX
     #elif defined(BINDINGS_GLFW_USE_WAYLAND)
       #define GLFW_EXPOSE_NATIVE_WAYLAND
-      #define GLFW_EXPOSE_NATIVE_EGL
     #elif defined(BINDINGS_GLFW_USE_MIR)
       #define GLFW_EXPOSE_NATIVE_MIR
-      #define GLFW_EXPOSE_NATIVE_EGL
     #endif
 
   #endif


### PR DESCRIPTION
EGL should always be available on Linux, even when X11 is used as the window creation API. For example, the following (in C) works just fine with X11:

```c
        // initialization...

        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);

        GLFWwindow* glfwWin = glfwCreateWindow( 640
                                              , 480
                                              , "dingas"
                                              , NULL
                                              , NULL
                                              );
        if(!glfwWin)
        {
                printf("glfwCreateWindow failed\n");
                return 1;
        }
        EGLSurface eglSurf = glfwGetEGLSurface(glfwWin);
        if(!eglSurf)
        {
                printf("glfwGetEGLSurface failed\n");
                return 1;
        }

        // eglSurf is the EGL surface backing our X11 window...
 ```