### PR TITLE
Allow newer minor for system package

### DIFF
--- a/bindings-GLFW.cabal
+++ b/bindings-GLFW.cabal
@@ -113,7 +113,7 @@ library
 
   if flag(system-glfw)
     pkgconfig-depends:
-      glfw3 == 3.3.*
+      glfw3 >= 3.3 && < 4
   else
     include-dirs:
       glfw/include/GLFW


### PR DESCRIPTION
I tested this locally and the changes in 3.4 are backwards-compatible.

Ctx: Debian stable started to ship 3.4. Other packages that link against are starting to detect and use its features, which results in API mismatch wrt vendored version. And the package can't use system version because it is currently locked to 3.3.

This can be an interim fix before going full vendored 3.4.